### PR TITLE
Allow configuring the scripts directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 HookHand is a small web application which runs scripts from webhooks.
 
 ## Features
-- Runs scripts from a cloned Git repository.
+- Runs scripts from a cloned Git repository or local directory.
 - Runs script and passes parameters based on URL path.
 - Webhook metadata can be passed through POSTed JSON or form data and is exposed to the script as environment variables.
 - Script output is returned as plain text.
@@ -24,6 +24,7 @@ SCRIPTS_GIT_REPO="..." foreman start
 
 ## Configuration Environment Variables
 - `REQUEST_TIMEOUT`: the time a script is allowed to run for before being killed. Defaults to 25 seconds.
+- `SCRIPTS_DIR`: a path to the directory either storing the scripts or a destination to clone `SCRIPTS_GIT_REPO` into. Defaults to `./scripts/` relative to the working directory.
 - `SCRIPTS_GIT_REPO`: the Git repository to clone for scripts.
 - `SCRIPTS_GIT_USERNAME`: the HTTP username for accessing the Git repository. Alternatively, a GitHub personal access token.
 - `SCRIPTS_GIT_PASSWORD`: the HTTP password for accessing the Git repository.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ SCRIPTS_GIT_REPO="..." foreman start
 2. Access http://localhost:5000/test/a/b/c and see that it is running the [test script](https://github.com/mikemcquaid/HookHandTestScripts/blob/master/test) and passing parameters `a b c`.
 3. Deploy to a server and set up a webhook with `http://yourserver/test/a/b/c` as the Payload URL and see that the webhook variables are exported in the format e.g. `HOOKHAND_REPOSITORY_CREATED_AT=1412962305`. If it's a private repository set the username and password with the `SCRIPTS_GIT_USERNAME` and `SCRIPTS_GIT_PASSWORD` environment variables (or set `SCRIPTS_GIT_USERNAME` to a personal access token).
 
+## Configuration Environment Variables
+- `REQUEST_TIMEOUT`: the time a script is allowed to run for before being killed. Defaults to 25 seconds.
+- `SCRIPTS_GIT_REPO`: the Git repository to clone for scripts.
+- `SCRIPTS_GIT_USERNAME`: the HTTP username for accessing the Git repository. Alternatively, a GitHub personal access token.
+- `SCRIPTS_GIT_PASSWORD`: the HTTP password for accessing the Git repository.
+
 ## Status
 The above features are implemented. Will fix bugs that come along but want to avoid scope-creep.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SCRIPTS_GIT_REPO="..." foreman start
 
 ## Example
 1. Run `SCRIPTS_GIT_REPO=https://github.com/mikemcquaid/HookHandTestScripts foreman start` to start the application and download the `HookHandTestScripts` repository.
-2. Access http://localhost:5000/test/a/b/c and see that it is running the [test script](https://github.com/mikemcquaid/HookHandTestScripts/blob/master/test) and passing parameters `a b c`.
+2. Access [http://localhost:5000/test/a/b/c](http://localhost:5000/test/a/b/c) and see that it is running the [test script](https://github.com/mikemcquaid/HookHandTestScripts/blob/master/test) and passing parameters `a b c`.
 3. Deploy to a server and set up a webhook with `http://yourserver/test/a/b/c` as the Payload URL and see that the webhook variables are exported in the format e.g. `HOOKHAND_REPOSITORY_CREATED_AT=1412962305`. If it's a private repository set the username and password with the `SCRIPTS_GIT_USERNAME` and `SCRIPTS_GIT_PASSWORD` environment variables (or set `SCRIPTS_GIT_USERNAME` to a personal access token).
 
 ## Configuration Environment Variables

--- a/hookhand.rb
+++ b/hookhand.rb
@@ -158,7 +158,11 @@ EOS
 ---
 Ran script '#{script_file}' #{script_status_message}
 EOS
-      status_code = script_success ? 200 : 500
+      status_code = if script_success
+        200
+      else
+        500
+      end
     elsif script_file
       body = "No script named '#{script_file}' found!"
       status_code = 404

--- a/hookhand.rb
+++ b/hookhand.rb
@@ -15,7 +15,7 @@ class Hookhand
     end
 
     scripts = ENV["RACK_ENV"] == "test" ? "test/scripts" : "scripts"
-    @scripts_dir = Pathname.new File.expand_path "#{__FILE__}/../#{scripts}/"
+    @scripts_dir = Pathname.new File.expand_path "#{File.dirname(__FILE__)}/scripts/"
 
     # Only run Git operations on the first Unicorn worker.
     # This is a filthy hack to prevent clobbering the same scripts Git

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,26 +1,28 @@
 ENV["RACK_ENV"] = "test"
 
+HOOKHAND_ROOT = File.expand_path "#{File.dirname(__FILE__)}/../"
+
 if ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.start do
     project_name "HookHand"
     add_filter "/test/"
     add_filter "/vendor/"
-    coverage_dir "test/coverage"
+    coverage_dir "#{HOOKHAND_ROOT}/test/coverage"
     minimum_coverage 100
   end
 end
 
 require "minitest/autorun"
 require "rack/test"
-require File.expand_path("#{File.dirname(__FILE__)}/../hookhand.rb")
+require "#{HOOKHAND_ROOT}/hookhand.rb"
 
 def home
-  File.expand_path("#{File.dirname(__FILE__)}/tmp")
+  File.expand_path "#{HOOKHAND_ROOT}/test/tmp"
 end
 
 def scripts
-  File.expand_path("#{File.dirname(__FILE__)}/scripts/")
+  File.expand_path "#{HOOKHAND_ROOT}/test/scripts"
 end
 
 cleanup = Proc.new { FileUtils.rm_rf home; FileUtils.rm_rf scripts }

--- a/test/test.rb
+++ b/test/test.rb
@@ -39,6 +39,7 @@ class HookHandTest < MiniTest::Unit::TestCase
   def setup
     FileUtils.mkdir_p home
     ENV["HOME"] = home
+    ENV["SCRIPTS_DIR"] = scripts
     ENV["SCRIPTS_GIT_USERNAME"] = "test"
     ENV["SCRIPTS_GIT_REPO"] = \
       "https://github.com/mikemcquaid/HookHandTestScripts"
@@ -53,6 +54,27 @@ class HookHandTest < MiniTest::Unit::TestCase
     get "/"
     assert last_response.ok?
     assert_equal "Welcome to HookHand!", last_response.body
+  end
+
+  def test_default_scripts_dir
+    ENV.delete "SCRIPTS_DIR"
+    get "/"
+    assert last_response.ok?
+  end
+
+  def test_set_existing_scripts_dir
+    ENV.delete "SCRIPTS_GIT_REPO"
+    FileUtils.mkdir_p ENV["SCRIPTS_DIR"]
+    assert File.directory? ENV["SCRIPTS_DIR"]
+    get "/"
+    assert last_response.ok?
+  end
+
+  def test_set_missing_scripts_dir
+    ENV.delete "SCRIPTS_GIT_REPO"
+    ENV["SCRIPTS_DIR"] = "./a/missing/directory"
+    assert !File.directory?(ENV["SCRIPTS_DIR"])
+    assert_raises(RuntimeError) { get "/" }
   end
 
   def test_invalid_scripts_repo


### PR DESCRIPTION
For example to allow a wrapper project to include the scripts in the same repository as the wrapper rather than requiring it to be a separate project.

Also:
- README: document environment variables
- hookhand.rb: don't use ternary operator for status code
- Cleanup uses of File.expand_path
- README: link the localhost:5000 URL.
