### PR TITLE
Better handle Git credentials.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.env
+/.git-credentials
 /bin/
 /scripts/
 /test/coverage/

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Alternatively, to deploy to [Heroku](https://www.heroku.com) click:
 ## Example
 1. Run `SCRIPTS_GIT_REPO=https://github.com/mikemcquaid/HookHandTestScripts foreman start` to start the application and download the `HookHandTestScripts` repository.
 2. Access [http://localhost:5000/test/a/b/c](http://localhost:5000/test/a/b/c) and see that it is running the [test script](https://github.com/mikemcquaid/HookHandTestScripts/blob/master/test) and passing parameters `a b c`.
-3. Deploy to a server and set up a webhook with `http://yourserver/test/a/b/c` as the Payload URL and see that the webhook variables are exported in the format e.g. `HOOKHAND_REPOSITORY_CREATED_AT=1412962305`. If it's a private repository set the username and password with the `SCRIPTS_GIT_USERNAME` and `SCRIPTS_GIT_PASSWORD` environment variables (or set `SCRIPTS_GIT_USERNAME` to a personal access token).
+3. Deploy to a server and set up a webhook with `http://yourserver/test/a/b/c` as the Payload URL and see that the webhook variables are exported in the format e.g. `HOOKHAND_REPOSITORY_CREATED_AT=1412962305`. If it's a private repository set the username and password with the `SCRIPTS_GIT_USERNAME` and `SCRIPTS_GIT_PASSWORD` environment variables (or set `SCRIPTS_GIT_PASSWORD` to a personal access token).
 
 ## Configuration Environment Variables
 - `REQUEST_TIMEOUT`: the number of seconds a script is allowed to run for before being killed. Defaults to 25.
 - `SCRIPTS_DIR`: a path to the directory either storing the scripts or a destination to clone `SCRIPTS_GIT_REPO` into. Defaults to `./scripts/` relative to the working directory.
 - `SCRIPTS_GIT_REPO`: the Git repository to clone for scripts.
-- `SCRIPTS_GIT_USERNAME`: the HTTP username for accessing a private Git repository. Alternatively, a GitHub personal access token.
-- `SCRIPTS_GIT_PASSWORD`: the HTTP password for accessing a private Git repository.
+- `SCRIPTS_GIT_USERNAME`: the HTTP username for accessing a private Git repository.
+- `SCRIPTS_GIT_PASSWORD`: the HTTP password for accessing a private Git repository. Alternatively, a GitHub personal access token.
 - `WEB_CONCURRENCY`: the number of Unicorn (web server) processes to run.
 
 ## Status

--- a/test/test.rb
+++ b/test/test.rb
@@ -17,15 +17,11 @@ require "minitest/autorun"
 require "rack/test"
 require "#{HOOKHAND_ROOT}/hookhand.rb"
 
-def home
-  File.expand_path "#{HOOKHAND_ROOT}/test/tmp"
-end
-
 def scripts
   File.expand_path "#{HOOKHAND_ROOT}/test/scripts"
 end
 
-cleanup = Proc.new { FileUtils.rm_rf home; FileUtils.rm_rf scripts }
+cleanup = Proc.new { FileUtils.rm_rf scripts }
 cleanup.call
 MiniTest::Unit.after_tests &cleanup
 
@@ -37,8 +33,6 @@ class HookHandTest < MiniTest::Unit::TestCase
   end
 
   def setup
-    FileUtils.mkdir_p home
-    ENV["HOME"] = home
     ENV["SCRIPTS_DIR"] = scripts
     ENV["SCRIPTS_GIT_USERNAME"] = "test"
     ENV["SCRIPTS_GIT_REPO"] = \


### PR DESCRIPTION
Instead of using the `~/.netrc` file use Git's credential store support.

Also, clarify in the README how Git credentials should be used.
