### PR TITLE
Require "timeout".

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "unicorn"
 
 group :development do
   gem "guard-process"
-  gem "awesome_print"
   gem "travis-lint"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    awesome_print (1.7.0)
     docile (1.1.5)
     ffi (1.9.14)
     guard-compat (1.2.1)
@@ -33,7 +32,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_print
   guard-process
   json
   minitest
@@ -45,7 +43,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.1.7p400
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.15.1

--- a/hookhand.rb
+++ b/hookhand.rb
@@ -1,7 +1,8 @@
 require "rack/request"
 require "rack/response"
 require "json"
-require "awesome_print" if ENV["RACK_ENV"] == "development"
+require "timeout"
+require "pp"
 
 # Let's timeout by default after 25s as e.g. Heroku times out after 30s.
 DEFAULT_REQUEST_TIMEOUT = 25


### PR DESCRIPTION
This must have been pulled in implicitly before but doesn't work now.

While we're here, use `pp` instead of `awesome_print`.